### PR TITLE
Add support for time durations

### DIFF
--- a/lib/king_konf.rb
+++ b/lib/king_konf.rb
@@ -2,7 +2,7 @@ require "king_konf/version"
 
 module KingKonf
   # Variable value types.
-  TYPES = %i(boolean integer float string list symbol)
+  TYPES = %i(boolean integer float string list symbol duration)
 
   ConfigError = Class.new(StandardError)
 end

--- a/lib/king_konf/decoder.rb
+++ b/lib/king_konf/decoder.rb
@@ -38,7 +38,10 @@ module KingKonf
     end
 
     def duration(value, **)
-      if value =~ /^\d*$/
+      case value
+      when ""
+        nil
+      when/^\d*$/
         value.to_i
       else
         DurationDecoder.decode(value)

--- a/lib/king_konf/decoder.rb
+++ b/lib/king_konf/decoder.rb
@@ -1,3 +1,5 @@
+require "king_konf/duration_decoder"
+
 module KingKonf
   module Decoder
     extend self
@@ -33,6 +35,14 @@ module KingKonf
 
     def float(value, **)
       Float(value)
+    end
+
+    def duration(value, **)
+      if value =~ /^\d*$/
+        value.to_i
+      else
+        DurationDecoder.decode(value)
+      end
     end
   end
 end

--- a/lib/king_konf/duration_decoder.rb
+++ b/lib/king_konf/duration_decoder.rb
@@ -2,7 +2,10 @@ module KingKonf
   # Decodes specially formatted duration strings.
   module DurationDecoder
     # Either a number or a time unit.
-    REGEX = /(\d+|[wdhms])/
+    PART = /(\d+|[wdhms])/
+
+    # One or more parts, possibly separated by whitespace.
+    VALID_DURATION = /^(#{PART}\s*)+$/
 
     UNITS = {
       "s" => 1,
@@ -13,7 +16,11 @@ module KingKonf
     }
 
     def self.decode(value)
-      value.scan(REGEX).flatten.each_slice(2).map {|number, letter|
+      if value !~ VALID_DURATION
+        raise ConfigError, "#{value.inspect} is not a duration: must be e.g. `1h 30m`"
+      end
+
+      value.scan(PART).flatten.each_slice(2).map {|number, letter|
         number.to_i * UNITS.fetch(letter)
       }.sum
     end

--- a/lib/king_konf/duration_decoder.rb
+++ b/lib/king_konf/duration_decoder.rb
@@ -1,0 +1,21 @@
+module KingKonf
+  # Decodes specially formatted duration strings.
+  module DurationDecoder
+    # Either a number or a time unit.
+    REGEX = /(\d+|[wdhms])/
+
+    UNITS = {
+      "s" => 1,
+      "m" => 60,
+      "h" => 60 * 60,
+      "d" => 60 * 60 * 24,
+      "w" => 60 * 60 * 24 * 7,
+    }
+
+    def self.decode(value)
+      value.scan(REGEX).flatten.each_slice(2).map {|number, letter|
+        number.to_i * UNITS.fetch(letter)
+      }.sum
+    end
+  end
+end

--- a/spec/decoder_spec.rb
+++ b/spec/decoder_spec.rb
@@ -33,8 +33,8 @@ describe KingKonf::Decoder do
       expect(KingKonf::Decoder.duration("100")).to eq 100
     end
 
-    it "decodes the empty string as zero" do
-      expect(KingKonf::Decoder.duration("")).to eq 0
+    it "decodes the empty string as nil" do
+      expect(KingKonf::Decoder.duration("")).to eq nil
     end
 
     it "decodes shorthand duration format" do

--- a/spec/decoder_spec.rb
+++ b/spec/decoder_spec.rb
@@ -49,5 +49,11 @@ describe KingKonf::Decoder do
       expect(KingKonf::Decoder.duration("1w 2d 1h 30m 10s")).to eq duration
       expect(KingKonf::Decoder.duration("1w2d1h30m10s")).to eq duration
     end
+
+    it "raises ConfigError on invalid input" do
+      expect {
+        KingKonf::Decoder.duration("hello")
+      }.to raise_exception(KingKonf::ConfigError, '"hello" is not a duration: must be e.g. `1h 30m`')
+    end
   end
 end

--- a/spec/decoder_spec.rb
+++ b/spec/decoder_spec.rb
@@ -27,4 +27,27 @@ describe KingKonf::Decoder do
       expect(KingKonf::Decoder.symbol("string")).to eq :string
     end
   end
+
+  describe ".duration" do
+    it "decodes plain integers as seconds" do
+      expect(KingKonf::Decoder.duration("100")).to eq 100
+    end
+
+    it "decodes the empty string as zero" do
+      expect(KingKonf::Decoder.duration("")).to eq 0
+    end
+
+    it "decodes shorthand duration format" do
+      duration = [
+        1 * 60 * 60 * 24 * 7,
+        2 * 60 * 60 * 24,
+        1 * 60 * 60,
+        30 * 60,
+        10,
+      ].sum
+
+      expect(KingKonf::Decoder.duration("1w 2d 1h 30m 10s")).to eq duration
+      expect(KingKonf::Decoder.duration("1w2d1h30m10s")).to eq duration
+    end
+  end
 end


### PR DESCRIPTION
Allow defining duration variables that accept either integers (whole seconds) or specially formatted strings, e.g. `30s`, `1h 25m`, etc.