### PR TITLE
allow strings to be passed to symbol types

### DIFF
--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -17,6 +17,7 @@ module KingKonf
       case @type
       when :float then value.to_f
       when :duration then value.is_a?(String) ? Decoder.duration(value) : value
+      when :symbol then value.is_a?(String) ? value.to_sym : value
       else value
       end
     end

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe KingKonf::Variable do
     end
   end
 
+  context "symbol" do
+    let(:var) { KingKonf::Variable.new(name: "codec", type: :symbol) }
+
+    it "casts strings" do
+      expect(var.cast("gzip")).to eq :gzip
+    end
+
+    it "doesn't cast integers" do
+      expect(var.cast(90)).to eq 90
+    end
+
+  end
   context "duration" do
     let(:var) { KingKonf::Variable.new(name: "timeout", type: :duration) }
 


### PR DESCRIPTION
Currently, it is not possible to pass a symbol type from a YAML file as YAML does not parse symbols. This PR means that KingKonf will try to cast strings to symbols when that is the data type specified. 