### PR TITLE
Mark strings as valid symbols

### DIFF
--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -34,7 +34,7 @@ module KingKonf
       when :float then value.is_a?(Float) || value.is_a?(Integer) || value.nil?
       when :duration then value.is_a?(Float) || value.is_a?(Integer) || value.is_a?(String) || value.nil?
       when :boolean then value == true || value == false
-      when :symbol then value.is_a?(Symbol)
+      when :symbol then value.is_a?(Symbol) || value.is_a?(String)
       else raise "invalid type #{@type}"
       end
     end

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe KingKonf::Variable do
   context "symbol" do
     let(:var) { KingKonf::Variable.new(name: "codec", type: :symbol) }
 
+    it "marks strings as valid" do
+      expect(var.valid?("gzip")).to eq true
+    end
+
     it "casts strings" do
       expect(var.cast("gzip")).to eq :gzip
     end


### PR DESCRIPTION
Valid is called before cast, so valid must also return true when symbol type variables are passed as strings.