### PR TITLE
Use `YAML.load` to load configuration file

### DIFF
--- a/lib/king_konf/config_file_loader.rb
+++ b/lib/king_konf/config_file_loader.rb
@@ -11,9 +11,7 @@ module KingKonf
       # First, load the ERB template from disk.
       template = ERB.new(File.new(path).read)
 
-      # The last argument to `safe_load` allows us to use aliasing to share
-      # configuration between environments.
-      data = YAML.safe_load(template.result(binding), [], [], true)
+      data = YAML.load(template.result(binding))
 
       # Grab just the config for the environment, if specified.
       data = data.fetch(environment) unless environment.nil?


### PR DESCRIPTION
Using `.load` might be vulnerable to attacks if you're loading user generated YAML file. Most use cases of this gem would only read developer generated YAML.

We're switching away from `.safe_load` to increase compatibility for e.g. Rails 3 and 4 applications that use `Syck` to parse YAML.

/cc @dasch 