### PR TITLE
Floats can now default to nil

### DIFF
--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -15,7 +15,7 @@ module KingKonf
 
     def cast(value)
       case @type
-      when :float then value.to_f
+      when :float then value.is_a?(String) || value.is_a?(Integer) ? value.to_f : value
       when :duration then value.is_a?(String) ? Decoder.duration(value) : value
       when :symbol then value.is_a?(String) ? value.to_sym : value
       else value

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -1,13 +1,23 @@
 require "king_konf"
 
 RSpec.describe KingKonf::Variable do
+  KingKonf::TYPES.each do |type|
+    context(type) do
+      let(:var) { KingKonf::Variable.new(name: "foo", type: type) }
+
+      it "defaults to nil" do
+        expect(var.default).to eq nil
+      end
+    end
+  end
+
   describe "#boolean?" do
     it "returns true if the variable is boolean" do
       variable = KingKonf::Variable.new(
         name: :tall,
         type: :boolean,
       )
-      
+
       expect(variable.boolean?).to eq true
     end
   end
@@ -24,10 +34,10 @@ RSpec.describe KingKonf::Variable do
     end
 
     it "doesn't cast integers" do
-      expect(var.cast(90)).to eq 90
+      expect(var.cast(90)).to eql 90
     end
-
   end
+
   context "duration" do
     let(:var) { KingKonf::Variable.new(name: "timeout", type: :duration) }
 
@@ -36,7 +46,19 @@ RSpec.describe KingKonf::Variable do
     end
 
     it "doesn't cast integers" do
-      expect(var.cast(90)).to eq 90
+      expect(var.cast(90)).to eql 90
+    end
+  end
+
+  context "float" do
+    let(:var) { KingKonf::Variable.new(name: "happiness", type: :float) }
+
+    it "casts integers" do
+      expect(var.cast(42)).to eql 42.0
+    end
+
+    it "casts strings" do
+      expect(var.cast("3.141")).to eql 3.141
     end
   end
 end


### PR DESCRIPTION
Previously, they would default to 0.0.

Also fixed a couple of eq/eql issues in the specs. E.g.

```
>> 42 == 42.0
true
>> 42.eql?(42.0)
false
```

cc @ronan-mch @dasch 