### PR TITLE
Config: avoid warning by defining ivar

### DIFF
--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -71,6 +71,7 @@ module KingKonf
 
     def initialize(env: ENV)
       @desc = nil
+      @ignore_unknown_variables = nil
       load_env(env)
     end
 

--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -70,6 +70,7 @@ module KingKonf
     end
 
     def initialize(env: ENV)
+      @desc = nil
       load_env(env)
     end
 


### PR DESCRIPTION
This PR tries to avoid warnings output by defining the `@desc` variable in the initializer.

Example warning:

```
/Users/olle/.rvm/gems/ruby-2.5.3/gems/king_konf-0.3.7/lib/king_konf/config.rb:37: warning: instance variable @desc not initialized
```