### PR TITLE
Add support for custom validation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ class MyApplication::Config < KingKonf::Config
 
   # You can restrict the set of allowed values:
   string :category, allowed_values: ["news", "stuff", "accouncements"]
+
+  # You can provide a custom validation function:
+  integer :even_number, validator: ->(int) { int % 2 == 0 }
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ class MyApplication::Config < KingKonf::Config
   string :category, allowed_values: ["news", "stuff", "accouncements"]
 
   # You can provide a custom validation function:
-  integer :even_number, validator: ->(int) { int % 2 == 0 }
+  integer :even_number, validate_with: ->(int) { int % 2 == 0 }
 end
 ```
 

--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -33,7 +33,7 @@ module KingKonf
       end
 
       TYPES.each do |type|
-        define_method(type) do |name, default: nil, required: false, allowed_values: nil, validator: ->(_) { true }, **options|
+        define_method(type) do |name, default: nil, required: false, allowed_values: nil, validate_with: ->(_) { true }, **options|
           description, @desc = @desc, nil
           variable = Variable.new(
             name: name,
@@ -42,7 +42,7 @@ module KingKonf
             required: required,
             description: description,
             allowed_values: allowed_values,
-            validator: validator,
+            validate_with: validate_with,
             options: options,
           )
 

--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -33,7 +33,7 @@ module KingKonf
       end
 
       TYPES.each do |type|
-        define_method(type) do |name, default: nil, required: false, allowed_values: nil, **options|
+        define_method(type) do |name, default: nil, required: false, allowed_values: nil, validator: ->(_) { true }, **options|
           description, @desc = @desc, nil
           variable = Variable.new(
             name: name,
@@ -42,6 +42,7 @@ module KingKonf
             required: required,
             description: description,
             allowed_values: allowed_values,
+            validator: validator,
             options: options,
           )
 
@@ -106,6 +107,10 @@ module KingKonf
 
       if !variable.allowed?(cast_value)
         raise ConfigError, "invalid value #{value.inspect} for variable `#{name}`, allowed values are #{variable.allowed_values}"
+      end
+
+      if !variable.valid?(value)
+        raise ConfigError, "invalid value #{value.inspect} for variable `#{name}`"
       end
 
       instance_variable_set("@#{name}", cast_value)

--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -2,15 +2,16 @@ require "king_konf/decoder"
 
 module KingKonf
   class Variable
-    attr_reader :name, :type, :default, :description, :allowed_values, :options
+    attr_reader :name, :type, :default, :description, :allowed_values, :validator, :options
 
-    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, options: {})
+    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, validator: ->(_) { true }, options: {})
       @name, @type = name, type
       @description = description
       @required = required
       @allowed_values = allowed_values
       @options = options
       @default = cast(default) unless default.nil?
+      @validator = validator
     end
 
     def cast(value)
@@ -31,11 +32,11 @@ module KingKonf
     end
 
     def valid?(value)
-      cast(value)
+      cast_value = cast(value)
     rescue ConfigError
       false
     else
-      true
+      !!validator.call(cast_value)
     end
 
     def allowed?(value)

--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -2,16 +2,16 @@ require "king_konf/decoder"
 
 module KingKonf
   class Variable
-    attr_reader :name, :type, :default, :description, :allowed_values, :validator, :options
+    attr_reader :name, :type, :default, :description, :allowed_values, :validate_with, :options
 
-    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, validator: ->(_) { true }, options: {})
+    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, validate_with: ->(_) { true }, options: {})
       @name, @type = name, type
       @description = description
       @required = required
       @allowed_values = allowed_values
       @options = options
       @default = cast(default) unless default.nil?
-      @validator = validator
+      @validate_with = validate_with
     end
 
     def cast(value)
@@ -36,7 +36,7 @@ module KingKonf
     rescue ConfigError
       false
     else
-      !!validator.call(cast_value)
+      !!validate_with.call(cast_value)
     end
 
     def allowed?(value)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -23,7 +23,7 @@ describe KingKonf::Config do
 
       duration :time_to_sleep, default: "8h"
 
-      integer :even_number, validator: ->(int) { int % 2 == 0 }
+      integer :even_number, validate_with: ->(int) { int % 2 == 0 }
     end
   }
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -22,6 +22,8 @@ describe KingKonf::Config do
       float :happiness, default: 1.0
 
       duration :time_to_sleep, default: "8h"
+
+      integer :even_number, validator: ->(int) { int % 2 == 0 }
     end
   }
 
@@ -50,6 +52,12 @@ describe KingKonf::Config do
       expect {
         config.level = "99"
       }.to_not raise_exception
+    end
+
+    it "raises ConfigError if a value is not valid" do
+      expect {
+        config.even_number = 3
+      }.to raise_exception(KingKonf::ConfigError, "invalid value 3 for variable `even_number`")
     end
   end
 

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe KingKonf::Variable do
 
     it "returns false if the value is invalid" do
       var = KingKonf::Variable.new(name: "codec", type: :integer, allowed_values: [:gzip])
-      
+
       expect(var.allowed?("yolo")).to eq false
     end
   end
@@ -33,6 +33,32 @@ RSpec.describe KingKonf::Variable do
       )
 
       expect(variable.boolean?).to eq true
+    end
+  end
+
+  describe "#valid?" do
+    it "returns true if the variable can be cast" do
+      var = KingKonf::Variable.new(name: "foo", type: :integer)
+
+      expect(var.valid?('1')).to eq true
+    end
+
+    it "returns false if the validation function returns false" do
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { int == 2 })
+
+      expect(var.valid?('1')).to eq false
+    end
+
+    it "returns true if the validation function returns true" do
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { int == 1 })
+
+      expect(var.valid?('1')).to eq true
+    end
+
+    it "returns a boolean if the validation function returns a non-boolean" do
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { Object.new })
+
+      expect(var.valid?('1')).to eq true
     end
   end
 

--- a/spec/variable_spec.rb
+++ b/spec/variable_spec.rb
@@ -44,19 +44,19 @@ RSpec.describe KingKonf::Variable do
     end
 
     it "returns false if the validation function returns false" do
-      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { int == 2 })
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validate_with: ->(int) { int == 2 })
 
       expect(var.valid?('1')).to eq false
     end
 
     it "returns true if the validation function returns true" do
-      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { int == 1 })
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validate_with: ->(int) { int == 1 })
 
       expect(var.valid?('1')).to eq true
     end
 
     it "returns a boolean if the validation function returns a non-boolean" do
-      var = KingKonf::Variable.new(name: "foo", type: :integer, validator: ->(int) { Object.new })
+      var = KingKonf::Variable.new(name: "foo", type: :integer, validate_with: ->(int) { Object.new })
 
       expect(var.valid?('1')).to eq true
     end


### PR DESCRIPTION
👋 @dasch, we ran into a case where we wanted to validate the preexisting ISO duration format (not the `king_konf` duration). This is my stab at adding support for custom validation functions, which would enable us to do just that.

/cc @fredefox