### PR TITLE
Improve the usability of configuring with ENV vars

### DIFF
--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -132,12 +132,15 @@ module KingKonf
       end
     end
 
+    def env_prefix
+      self.class.env_prefix ? "#{self.class.env_prefix.upcase}_" : ""
+    end
+
     def load_env(env)
       loaded_keys = []
-      prefix = self.class.env_prefix ? "#{self.class.env_prefix.upcase}_" : ""
 
       self.class.variables.each do |variable|
-        key = prefix + variable.name.upcase.to_s
+        key = env_prefix + variable.name.upcase.to_s
 
         if string = env[key]
           value = variable.decode(string)
@@ -146,13 +149,30 @@ module KingKonf
         end
       end
 
-
       unless self.class.ignore_unknown_variables?
-        env.keys.grep(/^#{prefix}/).each do |key|
+        env.keys.grep(/^#{env_prefix}/).each do |key|
           unless loaded_keys.include?(key)
-            raise ConfigError, "All environment variables starting with `#{prefix}` must by valid configuration variables, but `#{key}` does not match any such variable"
+            if closest_match = close_matching_env_var(key)
+              raise ConfigError, "Unknown environment variable `#{key}`. Did you mean `#{closest_match}`?"
+            else
+              raise ConfigError, "All environment variables starting with `#{env_prefix}` must by valid configuration variables, but `#{key}` does not match any such variable"
+            end
           end
         end
+      end
+    end
+
+    # Returns the closest matching defined variable name, or `nil` if no
+    # variable is close enough.
+    def close_matching_env_var(key)
+      closest_match = self.class.variables.map {|variable|
+        env_prefix + variable.name.upcase.to_s
+      }.min_by {|candidate|
+        DidYouMean::Levenshtein.distance(candidate, key)
+      }
+
+      if closest_match && DidYouMean::Levenshtein.distance(closest_match, key) <= 3
+        closest_match
       end
     end
   end

--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -150,7 +150,7 @@ module KingKonf
       unless self.class.ignore_unknown_variables?
         env.keys.grep(/^#{prefix}/).each do |key|
           unless loaded_keys.include?(key)
-            raise ConfigError, "unknown environment variable #{key}"
+            raise ConfigError, "All environment variables starting with `#{prefix}` must by valid configuration variables, but `#{key}` does not match any such variable"
           end
         end
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -189,7 +189,7 @@ describe KingKonf::Config do
 
       expect {
         config_class.new(env: env)
-      }.to raise_exception(KingKonf::ConfigError, "unknown environment variable TEST_MISSING")
+      }.to raise_exception(KingKonf::ConfigError, "All environment variables starting with `TEST_` must by valid configuration variables, but `TEST_MISSING` does not match any such variable")
     end
 
     it "can be configured to ignore unknown variables" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -192,6 +192,16 @@ describe KingKonf::Config do
       }.to raise_exception(KingKonf::ConfigError, "All environment variables starting with `TEST_` must by valid configuration variables, but `TEST_MISSING` does not match any such variable")
     end
 
+    it "raises ConfigError and suggests a specific variable if there's a close match" do
+      env = {
+        "TEST_GREETIGN" => "hello",
+      }
+
+      expect {
+        config_class.new(env: env)
+      }.to raise_exception(KingKonf::ConfigError, "Unknown environment variable `TEST_GREETIGN`. Did you mean `TEST_GREETING`?")
+    end
+
     it "can be configured to ignore unknown variables" do
       config_class = Class.new(KingKonf::Config) do
         env_prefix :test


### PR DESCRIPTION
* Improve the error message on unknown ENV vars with the defined config prefix.
* If there's a defined config variable that's close to the unknown ENV key, suggest that variable in the error message.