### PR TITLE
Allow deprecating variables

### DIFF
--- a/lib/king_konf/config.rb
+++ b/lib/king_konf/config.rb
@@ -33,7 +33,7 @@ module KingKonf
       end
 
       TYPES.each do |type|
-        define_method(type) do |name, default: nil, required: false, allowed_values: nil, validate_with: ->(_) { true }, **options|
+        define_method(type) do |name, default: nil, required: false, allowed_values: nil, validate_with: ->(_) { true }, deprecation_message: nil, **options|
           description, @desc = @desc, nil if defined?(@desc)
           variable = Variable.new(
             name: name,
@@ -43,6 +43,7 @@ module KingKonf
             description: description,
             allowed_values: allowed_values,
             validate_with: validate_with,
+            deprecation_message: deprecation_message,
             options: options,
           )
 
@@ -102,6 +103,10 @@ module KingKonf
       end
 
       variable = self.class.variable(name)
+
+      if variable.deprecated?
+        raise ConfigError, "`#{name}` has been deprecated: #{variable.deprecation_message}"
+      end
 
       cast_value = value.nil? ? nil : variable.cast(value)
 

--- a/lib/king_konf/variable.rb
+++ b/lib/king_konf/variable.rb
@@ -2,9 +2,9 @@ require "king_konf/decoder"
 
 module KingKonf
   class Variable
-    attr_reader :name, :type, :default, :description, :allowed_values, :validate_with, :options
+    attr_reader :name, :type, :default, :description, :allowed_values, :validate_with, :options, :deprecation_message
 
-    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, validate_with: ->(_) { true }, options: {})
+    def initialize(name:, type:, default: nil, description: "", required: false, allowed_values: nil, validate_with: ->(_) { true }, options: {}, deprecation_message: nil)
       @name, @type = name, type
       @description = description
       @required = required
@@ -12,6 +12,7 @@ module KingKonf
       @options = options
       @default = cast(default) unless default.nil?
       @validate_with = validate_with
+      @deprecation_message = deprecation_message
     end
 
     def cast(value)
@@ -43,6 +44,10 @@ module KingKonf
       allowed_values.nil? || allowed_values.include?(cast(value))
     rescue ConfigError
       false
+    end
+
+    def deprecated?
+      !!deprecation_message
     end
 
     def decode(value)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -209,4 +209,17 @@ describe KingKonf::Config do
       }.not_to raise_exception
     end
   end
+
+  it "allows deprecating variables" do
+    config_class = Class.new(KingKonf::Config) do
+      env_prefix :test
+      string :deprecated_var, deprecation_message: "please don't use this anymore"
+    end
+
+    config = config_class.new
+
+    expect {
+      config.deprecated_var = "hello"
+    }.to raise_exception(KingKonf::ConfigError, "`deprecated_var` has been deprecated: please don't use this anymore")
+  end
 end


### PR DESCRIPTION
I'm not sure we want to raise an exception here. Perhaps `warn` instead? Make it configurable?