### PR TITLE
Adding alias support for Psych 4.

### DIFF
--- a/lib/king_konf/config_file_loader.rb
+++ b/lib/king_konf/config_file_loader.rb
@@ -12,8 +12,10 @@ module KingKonf
       template = ERB.new(File.new(path).read)
 
       begin
+        # Without flag, loading the configuration file fails in Ruby 3.1 if it contains aliases.
         data = YAML.load(template.result(binding), aliases: true)
       rescue ArgumentError
+        # Covering prior YAML versions
         data = YAML.load(template.result(binding))
       end
 

--- a/lib/king_konf/config_file_loader.rb
+++ b/lib/king_konf/config_file_loader.rb
@@ -11,7 +11,11 @@ module KingKonf
       # First, load the ERB template from disk.
       template = ERB.new(File.new(path).read)
 
-      data = YAML.load(template.result(binding))
+      begin
+        data = YAML.load(template.result(binding), aliases: true)
+      rescue ArgumentError
+        data = YAML.load(template.result(binding))
+      end
 
       # Grab just the config for the environment, if specified.
       data = data.fetch(environment) unless environment.nil?

--- a/spec/fixtures/config.yml
+++ b/spec/fixtures/config.yml
@@ -1,2 +1,5 @@
-production:
+hello: &hello
   greeting: hello
+
+production:
+  <<: *hello


### PR DESCRIPTION
Without this, loading the configuration file fails in Ruby 3.1 if it contains aliases. This adds support for Ruby 3.1 without breaking it for prior versions.

This is the error I get without this change:

```
~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in `visit_Psych_Nodes_Alias': Unknown alias: common (Psych::BadAlias)
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:345:in `block in revive_hash'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `each_slice'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:343:in `revive_hash'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:167:in `visit_Psych_Nodes_Mapping'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:318:in `visit_Psych_Nodes_Document'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:335:in `safe_load'
	from ~/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:370:in `load'
	from ~/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/king_konf-1.0.0/lib/king_konf/config_file_loader.rb:14:in `load_file'
	from ~/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/king_konf-1.0.0/lib/king_konf/config.rb:81:in `load_file'
...
```